### PR TITLE
Use only directory name to run tests

### DIFF
--- a/spyder_unittesting/unittesting.py
+++ b/spyder_unittesting/unittesting.py
@@ -96,12 +96,10 @@ class UnitTesting(UnitTestingWidget, SpyderPluginMixin):
             self.dockwidget.raise_()
         pythonpath = self.main.get_spyder_pythonpath()
         runconf = runconfig.get_run_configuration(filename)
-        wdir, args = None, None
+        wdir = None
         if runconf is not None:
             if runconf.wdir_enabled:
                 wdir = runconf.wdir
-            if runconf.args_enabled:
-                args = runconf.args
 
-        UnitTestingWidget.analyze(self, filename, wdir=wdir, args=args,
+        UnitTestingWidget.analyze(self, filename, wdir=wdir,
                                   pythonpath=pythonpath)

--- a/spyder_unittesting/unittesting.py
+++ b/spyder_unittesting/unittesting.py
@@ -8,13 +8,15 @@
 
 """Unit testing Plugin"""
 
+import os.path as osp
+
 from qtpy.QtCore import Signal
 
 # Local imports
 from spyder.config.base import get_translation
 from spyder.utils.qthelpers import create_action
 from spyder.utils import icon_manager as ima
-from spyder.plugins import SpyderPluginMixin, runconfig
+from spyder.plugins import SpyderPluginMixin
 from .widgets.unittestinggui import (UnitTestingWidget, is_unittesting_installed)
 
 _ = get_translation("unittesting", dirname="spyder_unittesting")
@@ -86,20 +88,15 @@ class UnitTesting(UnitTestingWidget, SpyderPluginMixin):
     #------ Public API --------------------------------------------------------
     def run_unittesting(self):
         """Run unit testing"""
-        self.analyze(self.main.editor.get_current_filename())
+        filename = self.main.editor.get_current_filename()
+        dirname = osp.dirname(filename)
+        self.analyze(dirname)
 
-    def analyze(self, filename):
+    def analyze(self, wdir):
         """Reimplement analyze method"""
         if self.dockwidget and not self.ismaximized:
             self.dockwidget.setVisible(True)
             self.dockwidget.setFocus()
             self.dockwidget.raise_()
         pythonpath = self.main.get_spyder_pythonpath()
-        runconf = runconfig.get_run_configuration(filename)
-        wdir = None
-        if runconf is not None:
-            if runconf.wdir_enabled:
-                wdir = runconf.wdir
-
-        UnitTestingWidget.analyze(self, filename, wdir=wdir,
-                                  pythonpath=pythonpath)
+        UnitTestingWidget.analyze(self, wdir, pythonpath=pythonpath)

--- a/spyder_unittesting/unittesting.py
+++ b/spyder_unittesting/unittesting.py
@@ -62,7 +62,6 @@ class UnitTesting(UnitTestingWidget, SpyderPluginMixin):
     def register_plugin(self):
         """Register plugin in Spyder's main window"""
         self.edit_goto.connect(self.main.editor.load)
-        self.redirect_stdio.connect(self.main.redirect_internalshell_stdio)
         self.main.add_dockwidget(self)
 
         unittesting_act = create_action(

--- a/spyder_unittesting/unittesting.py
+++ b/spyder_unittesting/unittesting.py
@@ -1,8 +1,6 @@
 # -*- coding:utf-8 -*-
 #
-# Copyright © 2013 Joseph Martinot-Lagarde
-# based on p_profiler.py by Santiago Jaramillo
-#
+# Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 

--- a/spyder_unittesting/widgets/tests/test_unittestinggui.py
+++ b/spyder_unittesting/widgets/tests/test_unittestinggui.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2016- The Spyder Development Team
+# Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
-# (see ../../LICENSE for details)
+# (see spyder/__init__.py for details)
 
 """Tests for unittestinggui.py"""
 

--- a/spyder_unittesting/widgets/tests/test_unittestinggui.py
+++ b/spyder_unittesting/widgets/tests/test_unittestinggui.py
@@ -24,7 +24,7 @@ def test_run_tests_and_display_results(qtbot, tmpdir):
 
     widget = UnitTestingWidget(None)
     qtbot.addWidget(widget)
-    widget.analyze(testfilename)
+    widget.analyze(tmpdir.strpath)
     qtbot.wait(1000) # wait for tests to run
 
     datatree = widget.datatree

--- a/spyder_unittesting/widgets/unittestinggui.py
+++ b/spyder_unittesting/widgets/unittestinggui.py
@@ -163,7 +163,7 @@ class UnitTestingWidget(QWidget):
         else:
             pass  # self.show_data()
 
-    def analyze(self, filename, wdir=None, args=None, pythonpath=None):
+    def analyze(self, filename, wdir=None, pythonpath=None):
         if not is_unittesting_installed():
             return
         self.kill_if_running()
@@ -178,7 +178,7 @@ class UnitTestingWidget(QWidget):
         if self.filecombo.is_valid():
             if wdir is None:
                 wdir = osp.dirname(filename)
-            self.start(wdir, args, pythonpath)
+            self.start(wdir, pythonpath)
 
     def select_file(self):
         self.redirect_stdio.emit(False)
@@ -198,7 +198,7 @@ class UnitTestingWidget(QWidget):
             TextEditor(self.error_output, title=_("Unit testing output"),
                        readonly=True, size=(700, 500)).exec_()
 
-    def start(self, wdir=None, args=None, pythonpath=None):
+    def start(self, wdir=None, pythonpath=None):
         filename = to_text_string(self.filecombo.currentText())
         if wdir is None:
             wdir = self._last_wdir
@@ -209,14 +209,9 @@ class UnitTestingWidget(QWidget):
             # confusion with escape characters (otherwise, for example, '\t'
             # will be interpreted as a tabulation):
             filename = osp.normpath(filename).replace(os.sep, '/')
-        if args is None:
-            args = self._last_args
-            if args is None:
-                args = []
         if pythonpath is None:
             pythonpath = self._last_pythonpath
         self._last_wdir = wdir
-        self._last_args = args
         self._last_pythonpath = pythonpath
 
         self.datelabel.setText(_('Running tests, please wait...'))
@@ -249,8 +244,6 @@ class UnitTestingWidget(QWidget):
 #        executable = "nosetests"
 #        p_args = ['--with-xunit', "--xunit-file=%s" % self.DATAPATH]
 
-        if args:
-            p_args.extend(programs.shell_split(args))
         self.process.start(executable, p_args)
 
         running = self.process.waitForStarted()

--- a/spyder_unittesting/widgets/unittestinggui.py
+++ b/spyder_unittesting/widgets/unittestinggui.py
@@ -90,7 +90,7 @@ class UnitTestingWidget(QWidget):
             self, icon=ima.icon('run'),
             text=_("Run tests"),
             tip=_("Run unit testing"),
-            triggered=self.start, text_beside_icon=True)
+            triggered=self.start_test_process, text_beside_icon=True)
         self.stop_button = create_toolbutton(
             self, icon=ima.icon('stop'),
             text=_("Stop"),
@@ -178,7 +178,7 @@ class UnitTestingWidget(QWidget):
         if self.filecombo.is_valid():
             if wdir is None:
                 wdir = osp.dirname(filename)
-            self.start(wdir, pythonpath)
+            self.start_test_process(wdir, pythonpath)
 
     def select_file(self):
         self.redirect_stdio.emit(False)
@@ -198,7 +198,22 @@ class UnitTestingWidget(QWidget):
             TextEditor(self.error_output, title=_("Unit testing output"),
                        readonly=True, size=(700, 500)).exec_()
 
-    def start(self, wdir=None, pythonpath=None):
+    def start_test_process(self, wdir=None, pythonpath=None):
+        """
+        Start the process for running tests.
+
+        The process's output is consumed by `read_output()`.
+        When the process finishes, the `finish` signal is emitted.
+
+        Parameters
+        ----------
+        wdir : str
+            working directory to switch to when running tests.
+            If None, use `self._last_wdir` or path of file in combo box.
+        pythonpath : list of str
+            directories to be added to system python path.
+            If None, use `self._last_pythonpath`.
+        """
         filename = to_text_string(self.filecombo.currentText())
         if wdir is None:
             wdir = self._last_wdir

--- a/spyder_unittesting/widgets/unittestinggui.py
+++ b/spyder_unittesting/widgets/unittestinggui.py
@@ -13,7 +13,7 @@ Unit Testing widget
 from __future__ import with_statement
 
 from qtpy.QtCore import (QByteArray, QProcess, QProcessEnvironment, Qt,
-                         QTextCodec, Signal)
+                         QTextCodec)
 from qtpy.QtGui import QBrush, QColor, QFont
 from qtpy.QtWidgets import (QApplication, QHBoxLayout, QWidget, QMessageBox, 
                             QVBoxLayout, QLabel, QTreeWidget, QTreeWidgetItem)
@@ -68,7 +68,6 @@ class UnitTestingWidget(QWidget):
     """
     DATAPATH = get_conf_path('unittesting.results')
     VERSION = '0.0.1'
-    redirect_stdio = Signal(bool)
 
     def __init__(self, parent):
         QWidget.__init__(self, parent)
@@ -177,9 +176,7 @@ class UnitTestingWidget(QWidget):
             self.start_test_process(wdir, pythonpath)
 
     def select_dir(self):
-        self.redirect_stdio.emit(False)
         dirname = getexistingdirectory(self, _("Select directory"), getcwd())
-        self.redirect_stdio.emit(False)
         if dirname:
             self.analyze(dirname)
 

--- a/spyder_unittesting/widgets/unittestinggui.py
+++ b/spyder_unittesting/widgets/unittestinggui.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright © 2011 Santiago Jaramillo
-# based on pylintgui.py by Pierre Raybaut
-#
+# Copyright © Spyder Project Contributors
 # Licensed under the terms of the MIT License
 # (see spyder/__init__.py for details)
 


### PR DESCRIPTION
Only the directory name was actually used, so remove all references to the file name and the arguments from the running configuration. Fixes #8.